### PR TITLE
Fix icons not showing up in GUI when compiled

### DIFF
--- a/.github/workflows/gui.yml
+++ b/.github/workflows/gui.yml
@@ -44,7 +44,7 @@ jobs:
           python -m pip install -r GUI/requirements.txt
 
       - name: Build GUI
-        run: pyinstaller GUI/app.py --onefile --name VRCGUI --icon GUI/lib/img/logo.ico --add-data "GUI/lib/img;lib/img" --noconfirm
+        run: python GUI/build.py
 
       - name: Upload GUI to Release
         if: github.event_name != 'pull_request'

--- a/GUI/build.py
+++ b/GUI/build.py
@@ -1,0 +1,20 @@
+import os
+import subprocess
+
+THIS_DIR = os.path.abspath(os.path.dirname(__file__))
+
+cmd = [
+    "pyinstaller",
+    os.path.join(THIS_DIR, "app.py"),
+    "--onedir",
+    "--noconfirm",
+    "--name",
+    "VRCGUI",
+    "--icon",
+    os.path.join(THIS_DIR, "lib", "img", "logo.ico"),
+    "--add-data",
+    f"{os.path.join(THIS_DIR, 'lib', 'img')}{os.pathsep}{os.path.join('lib', 'img')}",
+]
+
+print(cmd)
+subprocess.check_call(cmd)

--- a/GUI/lib/config.py
+++ b/GUI/lib/config.py
@@ -1,12 +1,21 @@
 import json
 import os
+import sys
 from typing import Any
+
+if getattr(sys, "frozen", False):
+    DATA_DIR = sys._MEIPASS  # type: ignore
+    ROOT_DIR = os.path.dirname(sys.executable)
+else:
+    DATA_DIR = os.path.join(os.path.dirname(__file__), "..")
+    ROOT_DIR = DATA_DIR
+
+ROOT_DIR = os.path.abspath(ROOT_DIR)
+DATA_DIR = os.path.abspath(DATA_DIR)
 
 
 class _Config:
-    config_file = os.path.abspath(
-        os.path.join(os.path.dirname(__file__), "..", "settings.json")
-    )
+    config_file = os.path.join(ROOT_DIR, "settings.json")
 
     def __read(self) -> dict:
         if not os.path.isfile(self.config_file):

--- a/GUI/lib/qt_icon.py
+++ b/GUI/lib/qt_icon.py
@@ -1,12 +1,10 @@
 import os
-import sys
 
 from PySide6 import QtGui, QtWidgets
 
-if getattr(sys, "frozen", False):
-    IMG_DIR = os.path.join(sys._MEIPASS, "img")  # type: ignore
-else:
-    IMG_DIR = os.path.join(os.path.dirname(__file__), "img")
+from .config import DATA_DIR
+
+IMG_DIR = os.path.join(DATA_DIR, "lib", "img")
 
 
 def set_icon(widget: QtWidgets.QWidget) -> None:


### PR DESCRIPTION
Moved the pyinstaller command out of GitHub actions and into a separate build script. Did this for ease of compilation while testing.

Tested the fix both in one file and one directory mode.