### PR TITLE
Remove duplicate config items

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -29,15 +29,16 @@ updates:
     schedule:
       interval: "monthly"
 
-  - package-ecosystem: "pip"
-    directory: "/GUI"
-    schedule:
-      interval: "monthly"
+  # dependabot seems willing to look 1 level deep
+  # - package-ecosystem: "pip"
+  #   directory: "/GUI"
+  #   schedule:
+  #     interval: "monthly"
 
-  - package-ecosystem: "pip"
-    directory: "/PCC"
-    schedule:
-      interval: "monthly"
+  # - package-ecosystem: "pip"
+  #   directory: "/PCC"
+  #   schedule:
+  #     interval: "monthly"
 
   - package-ecosystem: "pip"
     directory: "/VMC/apriltag/python"


### PR DESCRIPTION
Dependabot seems willing to also look 1 folder level deep for Python files 🤷‍♂️. As a fix, comment out the duplicate entries. See this page on what is being monitored: https://github.com/bellflight/VRC-2022/network/updates