### PR TITLE
fixed max/min check and underlying servo call in absolute servo move

### DIFF
--- a/PCC/libraries/AVR_ServoDriver/avr_servo.cpp
+++ b/PCC/libraries/AVR_ServoDriver/avr_servo.cpp
@@ -28,12 +28,7 @@ void AVRServo::set_servo_percent(uint8_t servo, uint8_t percent)
 
 void AVRServo::set_servo_absolute(uint8_t servo, uint16_t absolute)
 {
-    if (absolute > SERVOMAX)
-        absolute = SERVOMAX;
-    if (absolute < SERVOMIN)
-        absolute = SERVOMIN;
-
-    setPWM(servo, 0, absolute);
+    writeMicroseconds(servo, absolute);
 }
 
 uint8_t AVRServo::check_controller(void)


### PR DESCRIPTION
Fixed the max/min checks that were preventing servo control properly in absolute mode