### PR TITLE
Use custom GitHub Action to deploy site

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -53,13 +53,13 @@ jobs:
           path: public
 
   docs-deploy:
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
-
     runs-on: ubuntu-latest
     if: "!contains(github.event.head_commit.message, 'ci skip') && github.event_name != 'pull_request'"
     needs: docs-build
+
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
 
     steps:
       - name: Deploy to GitHub Pages

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -54,7 +54,8 @@ jobs:
 
   docs-deploy:
     runs-on: ubuntu-latest
-    if: "!contains(github.event.head_commit.message, 'ci skip') && github.event_name != 'pull_request'"
+    if: github.event_name != 'pull_request'
+    # this will not run if docs-build does not run first
     needs: docs-build
 
     environment:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,4 +1,4 @@
-name: Build Docs
+name: Build and Deploy Docs
 
 on:
   workflow_dispatch:
@@ -11,6 +11,7 @@ on:
 
 concurrency:
   group: pages
+  cancel-in-progress: false
 
 jobs:
   docs-build:
@@ -26,7 +27,7 @@ jobs:
 
       - name: Setup Pages
         id: pages
-        uses: actions/configure-pages@v1
+        uses: actions/configure-pages@v2
 
       - name: Setup Node
         uses: actions/setup-node@v3
@@ -45,10 +46,22 @@ jobs:
         env:
           HUGO_BASEURL: ${{ steps.pages.outputs.base_url }}
 
-      - name: Deploy Site
+      - name: Upload artifact
         if: github.event_name != 'pull_request'
-        uses: peaceiris/actions-gh-pages@v3
+        uses: actions/upload-pages-artifact@v1
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_branch: gh-pages
-          publish_dir: public
+          path: public
+
+  docs-deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+
+    runs-on: ubuntu-latest
+    if: "!contains(github.event.head_commit.message, 'ci skip') && github.event_name != 'pull_request'"
+    needs: docs-build
+
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v1


### PR DESCRIPTION
This uses new GitHub Actions functionality to directly build and deploy the docs site, without needing to go through the `gh-pages` branch. This should make the deployment process faster, and reduce the size of the repository, and follows GitHub best practices.

Before this PR is merged, @noelbrownback or @nholowskobell, the repo Pages site needs to be changed to no longer use a branch source, but rather a Actions source.

After this PR is merged, delete the `gh-pages` in GitHub and locally to save space.