### PR TITLE
Fix apriltags/raw topic JSON format

### DIFF
--- a/VMC/apriltag/c/src/avrapriltags.cpp
+++ b/VMC/apriltag/c/src/avrapriltags.cpp
@@ -98,7 +98,7 @@ int main()
             //send the frame to GPU memory and run the detections
             uint32_t num_detections = process_frame(img_rgba8, impl_);
 
-            std::string payload = "\"tags\":{[";
+            std::string payload = "{\"tags\":[";
 
             //handle the detections
             for (int i = 0; i < num_detections; i++)

--- a/VMC/mavp2p/Dockerfile
+++ b/VMC/mavp2p/Dockerfile
@@ -1,6 +1,6 @@
 FROM docker.io/arm64v8/alpine:3
 
-ENV MAVP2P_VERSION=0.7.0
+ENV MAVP2P_VERSION=0.6.5
 WORKDIR /app
 
 RUN apk add wget tar

--- a/VMC/mavp2p/Dockerfile
+++ b/VMC/mavp2p/Dockerfile
@@ -1,6 +1,6 @@
 FROM docker.io/arm64v8/alpine:3
 
-ENV MAVP2P_VERSION=0.6.5
+ENV MAVP2P_VERSION=0.7.0
 WORKDIR /app
 
 RUN apk add wget tar


### PR DESCRIPTION
This prevents a lot of autonomy code from working, let's get this reviewed and merged to main ASAP.

Example from before: 
```
"tags":{[{"id":3,"pos":{"x":-0.12932901,"y":0.14244008,"z":0.99029773},"rotation":[[-0.9784445,0.009035255,-0.20631199],[-0.009233911,-0.9999574,7.966355e-18],[-0.2063032,0.0019050664,0.97848624]]}]}
```

Just move the one curly brace and problem solved.