### PR TITLE
Add autocomplete to MQTT Debugger

### DIFF
--- a/GUI/app/tabs/autonomy.py
+++ b/GUI/app/tabs/autonomy.py
@@ -42,7 +42,7 @@ class AutonomyWidget(BaseTabWidget):
 
         self.autonomous_label = QtWidgets.QLabel()
         self.autonomous_label.setAlignment(
-            QtCore.Qt.AlignRight | QtCore.Qt.AlignVCenter
+            QtCore.Qt.AlignmentFlag.AlignRight | QtCore.Qt.AlignmentFlag.AlignVCenter
         )
         autonomous_layout.addWidget(self.autonomous_label)
 
@@ -83,7 +83,10 @@ class AutonomyWidget(BaseTabWidget):
             building_layout.addWidget(building_disable_button)
 
             building_label = QtWidgets.QLabel()
-            building_label.setAlignment(QtCore.Qt.AlignRight | QtCore.Qt.AlignVCenter)
+            building_label.setAlignment(
+                QtCore.Qt.AlignmentFlag.AlignRight
+                | QtCore.Qt.AlignmentFlag.AlignVCenter
+            )
             building_layout.addWidget(building_label)
             self.building_labels.append(building_label)
 

--- a/GUI/app/tabs/connection/main.py
+++ b/GUI/app/tabs/connection/main.py
@@ -31,7 +31,7 @@ class MainConnectionWidget(BaseTabWidget):
         mqtt_layout.addWidget(self.mqtt_connection_widget)
 
         mqtt_groupbox.setSizePolicy(
-            QtWidgets.QSizePolicy.Expanding, QtWidgets.QSizePolicy.Fixed
+            QtWidgets.QSizePolicy.Policy.Expanding, QtWidgets.QSizePolicy.Policy.Fixed
         )
         layout.addWidget(mqtt_groupbox)
 
@@ -44,6 +44,6 @@ class MainConnectionWidget(BaseTabWidget):
         serial_layout.addWidget(self.serial_connection_widget)
 
         serial_groupbox.setSizePolicy(
-            QtWidgets.QSizePolicy.Expanding, QtWidgets.QSizePolicy.Fixed
+            QtWidgets.QSizePolicy.Policy.Expanding, QtWidgets.QSizePolicy.Policy.Fixed
         )
         layout.addWidget(serial_groupbox)

--- a/GUI/app/tabs/moving_map.py
+++ b/GUI/app/tabs/moving_map.py
@@ -82,8 +82,8 @@ class AttitudeIndicator(QtWidgets.QGraphicsView):
         # styling
         self.setFixedSize(self._original_width, self._original_height)
         self.setStyleSheet("background: transparent; border: none")
-        self.setHorizontalScrollBarPolicy(QtCore.Qt.ScrollBarAlwaysOff)
-        self.setVerticalScrollBarPolicy(QtCore.Qt.ScrollBarAlwaysOff)
+        self.setHorizontalScrollBarPolicy(QtCore.Qt.ScrollBarPolicy.ScrollBarAlwaysOff)
+        self.setVerticalScrollBarPolicy(QtCore.Qt.ScrollBarPolicy.ScrollBarAlwaysOff)
 
         # create a graphics scene to draw on
         self._scene = QtWidgets.QGraphicsScene(self)
@@ -246,7 +246,9 @@ class DroneAltitudeWidget(QtWidgets.QWidget):
         sub_layout.addStretch()
 
         layout.addLayout(sub_layout)
-        self.setSizePolicy(QtWidgets.QSizePolicy.Fixed, QtWidgets.QSizePolicy.Fixed)
+        self.setSizePolicy(
+            QtWidgets.QSizePolicy.Policy.Fixed, QtWidgets.QSizePolicy.Policy.Fixed
+        )
 
         # put drone on the ground
         self.set_altitude(0)
@@ -302,18 +304,18 @@ class MovingMapGraphicsView(QtWidgets.QGraphicsView):
         """
         Enable panning within the view.
         """
-        self.setDragMode(QtWidgets.QGraphicsView.ScrollHandDrag)
-        self.setHorizontalScrollBarPolicy(QtCore.Qt.ScrollBarAsNeeded)
-        self.setVerticalScrollBarPolicy(QtCore.Qt.ScrollBarAsNeeded)
+        self.setDragMode(QtWidgets.QGraphicsView.DragMode.ScrollHandDrag)
+        self.setHorizontalScrollBarPolicy(QtCore.Qt.ScrollBarPolicy.ScrollBarAsNeeded)
+        self.setVerticalScrollBarPolicy(QtCore.Qt.ScrollBarPolicy.ScrollBarAsNeeded)
 
     def disable_panning(self) -> None:
         """
         Disable panning within the view, if the viewport is being
         driven programmatically
         """
-        self.setDragMode(QtWidgets.QGraphicsView.NoDrag)
-        self.setHorizontalScrollBarPolicy(QtCore.Qt.ScrollBarAlwaysOff)
-        self.setVerticalScrollBarPolicy(QtCore.Qt.ScrollBarAlwaysOff)
+        self.setDragMode(QtWidgets.QGraphicsView.DragMode.NoDrag)
+        self.setHorizontalScrollBarPolicy(QtCore.Qt.ScrollBarPolicy.ScrollBarAlwaysOff)
+        self.setVerticalScrollBarPolicy(QtCore.Qt.ScrollBarPolicy.ScrollBarAlwaysOff)
 
 
 class InfiniteGridGraphicsScene(QtWidgets.QGraphicsScene):

--- a/GUI/app/tabs/mqtt_debug.py
+++ b/GUI/app/tabs/mqtt_debug.py
@@ -153,19 +153,19 @@ class MQTTDebugWidget(BaseTabWidget):
         layout = QtWidgets.QVBoxLayout(self)
         self.setLayout(layout)
 
-        main_layout = QtWidgets.QSplitter(QtCore.Qt.Vertical)
+        main_layout = QtWidgets.QSplitter(QtCore.Qt.Orientation.Vertical)
         layout.addWidget(main_layout)
 
         # viewing widget
         viewer_widget = QtWidgets.QGroupBox("Viewer")
         viewer_layout = QtWidgets.QVBoxLayout()
-        viewer_splitter = QtWidgets.QSplitter(QtCore.Qt.Horizontal)
+        viewer_splitter = QtWidgets.QSplitter(QtCore.Qt.Orientation.Horizontal)
         viewer_widget.setLayout(viewer_layout)
 
         self.tree_widget = ExpandCollapseQTreeWidget(self)
         self.tree_widget.setHeaderLabels(["Topic", "# Messages"])
         self.tree_widget.setSortingEnabled(True)
-        self.tree_widget.sortByColumn(0, QtCore.Qt.AscendingOrder)
+        self.tree_widget.sortByColumn(0, QtCore.Qt.SortOrder.AscendingOrder)
         self.tree_widget.setAnimated(True)
         self.tree_widget.setIndentation(10)
         self.tree_widget.itemSelectionChanged.connect(self.connect_topic_to_display)  # type: ignore
@@ -193,10 +193,10 @@ class MQTTDebugWidget(BaseTabWidget):
         self.topic_combo_box.addItems(list(MQTTTopics))
         # allow custom text, but don't modify the original data set
         self.topic_combo_box.setEditable(True)
-        self.topic_combo_box.setInsertPolicy(QtWidgets.QComboBox.NoInsert)
+        self.topic_combo_box.setInsertPolicy(QtWidgets.QComboBox.InsertPolicy.NoInsert)
         # change completer to have a popup
         self.topic_combo_box.completer().setCompletionMode(
-            QtWidgets.QCompleter.PopupCompletion
+            QtWidgets.QCompleter.CompletionMode.PopupCompletion
         )
         self.topic_combo_box.setCurrentText("")
         sender_layout.addRow(QtWidgets.QLabel("Topic:"), self.topic_combo_box)
@@ -365,8 +365,8 @@ class MQTTDebugWidget(BaseTabWidget):
         """
         topic = _rebuild_topic(item)
 
-        self.clipboard.clear(mode=self.clipboard.Clipboard)
-        self.clipboard.setText(topic, mode=self.clipboard.Clipboard)
+        self.clipboard.clear(mode=self.clipboard.Mode.Clipboard)
+        self.clipboard.setText(topic, mode=self.clipboard.Mode.Clipboard)
 
     def copy_payload(self, item: QtWidgets.QTreeWidgetItem) -> None:
         """
@@ -375,8 +375,8 @@ class MQTTDebugWidget(BaseTabWidget):
         topic = _rebuild_topic(item)
         payload = self.get_payload(topic)
 
-        self.clipboard.clear(mode=self.clipboard.Clipboard)
-        self.clipboard.setText(payload, mode=self.clipboard.Clipboard)
+        self.clipboard.clear(mode=self.clipboard.Mode.Clipboard)
+        self.clipboard.setText(payload, mode=self.clipboard.Mode.Clipboard)
 
     def preload_data(self, item: QtWidgets.QTreeWidgetItem) -> None:
         """

--- a/GUI/app/tabs/mqtt_debug.py
+++ b/GUI/app/tabs/mqtt_debug.py
@@ -4,6 +4,7 @@ import contextlib
 import json
 from typing import Any, Dict, List, Optional, Tuple
 
+from bell.avr.mqtt.constants import MQTTTopicPayload, MQTTTopics
 from PySide6 import QtCore, QtGui, QtWidgets
 
 from .base import BaseTabWidget
@@ -61,9 +62,6 @@ class ExpandCollapseQTreeWidget(QtWidgets.QTreeWidget):
     copy_topic: QtCore.SignalInstance = QtCore.Signal(object)  # type: ignore
     copy_payload: QtCore.SignalInstance = QtCore.Signal(object)  # type: ignore
     preload_data: QtCore.SignalInstance = QtCore.Signal(object)  # type: ignore
-
-    def __init__(self, *args, **kwargs) -> None:
-        super().__init__(*args, **kwargs)
 
     def contextMenuEvent(self, event: QtGui.QContextMenuEvent) -> None:
         # override the normal right click event. This only works on the TreeWidget
@@ -191,10 +189,22 @@ class MQTTDebugWidget(BaseTabWidget):
         sender_layout = QtWidgets.QFormLayout()
         sender_widget.setLayout(sender_layout)
 
-        self.topic_line_edit = QtWidgets.QLineEdit()
-        sender_layout.addRow(QtWidgets.QLabel("Topic:"), self.topic_line_edit)
+        self.topic_combo_box = QtWidgets.QComboBox()
+        self.topic_combo_box.addItems(list(MQTTTopics))
+        # allow custom text, but don't modify the original data set
+        self.topic_combo_box.setEditable(True)
+        self.topic_combo_box.setInsertPolicy(QtWidgets.QComboBox.NoInsert)
+        # change completer to have a popup
+        self.topic_combo_box.completer().setCompletionMode(
+            QtWidgets.QCompleter.PopupCompletion
+        )
+        self.topic_combo_box.setCurrentText("")
+        sender_layout.addRow(QtWidgets.QLabel("Topic:"), self.topic_combo_box)
+
+        self.payload_text_edit_interaction = False
         self.payload_text_edit = QtWidgets.QPlainTextEdit()
         sender_layout.addRow(QtWidgets.QLabel("Payload:"), self.payload_text_edit)
+
         self.send_button = QtWidgets.QPushButton("Send")
         sender_layout.addRow(self.send_button)
 
@@ -205,9 +215,11 @@ class MQTTDebugWidget(BaseTabWidget):
         self.tree_widget.copy_payload.connect(self.copy_payload)
         self.tree_widget.preload_data.connect(self.preload_data)
 
+        self.topic_combo_box.textActivated.connect(self.topic_selected)  # type: ignore
+        self.payload_text_edit.textChanged.connect(self.reset_payload_text_edit_interaction)  # type: ignore
         self.send_button.clicked.connect(  # type: ignore
             lambda: self.send_message(
-                self.topic_line_edit.text(), self.payload_text_edit.toPlainText()
+                self.topic_combo_box.currentText(), self.payload_text_edit.toPlainText()
             )
         )
 
@@ -373,5 +385,32 @@ class MQTTDebugWidget(BaseTabWidget):
         topic = _rebuild_topic(item)
         payload = self.get_payload(topic)
 
-        self.topic_line_edit.setText(topic)
+        self.topic_combo_box.setCurrentText(topic)
         self.payload_text_edit.setPlainText(payload)
+
+    def reset_payload_text_edit_interaction(self) -> None:
+        """
+        When the user changes text in the text edit, consider it to have been
+        interacted with. Only exception is if it has been blanked.
+        """
+        # if there is already text, consider the user to have interacted
+        # if there is no text, reset interaction tracker
+        self.payload_text_edit_interaction = self.payload_text_edit.toPlainText() != ""
+
+    def topic_selected(self, text: str) -> None:
+        """
+        When a topic is selected from QCompletor, create an empty JSON structure
+        to help the user.
+        """
+        # skip if the user has edited text since we last set it
+        if self.payload_text_edit_interaction:
+            return
+
+        payload = MQTTTopicPayload[self.topic_combo_box.currentText()]
+        starter_data = {key: None for key in payload.__required_keys__}
+
+        self.payload_text_edit.blockSignals(True)
+        self.payload_text_edit.setPlainText(json.dumps(starter_data, indent=4))
+        self.payload_text_edit.blockSignals(False)
+
+        self.payload_text_edit_interaction = False

--- a/GUI/app/tabs/mqtt_logger.py
+++ b/GUI/app/tabs/mqtt_logger.py
@@ -32,7 +32,7 @@ class LogFileViewWidget(QtWidgets.QTreeView):
         self.setItemsExpandable(False)
 
         self.setSortingEnabled(True)
-        self.sortByColumn(0, QtCore.Qt.DescendingOrder)
+        self.sortByColumn(0, QtCore.Qt.SortOrder.DescendingOrder)
 
         # open files on double click
         self.doubleClicked.connect(lambda index: os.startfile(self.filesystem_model.filePath(index)))  # type: ignore

--- a/GUI/app/tabs/pcc_tester.py
+++ b/GUI/app/tabs/pcc_tester.py
@@ -121,7 +121,7 @@ class PCCTesterWidget(BaseTabWidget):
         red_led_label = QtWidgets.QLabel("Red")
         led_layout.addWidget(red_led_label, 0, 0, 1, 1)
 
-        self.red_led_slider = QtWidgets.QSlider(QtCore.Qt.Horizontal)
+        self.red_led_slider = QtWidgets.QSlider(QtCore.Qt.Orientation.Horizontal)
         self.red_led_slider.setRange(0, 255)
         led_layout.addWidget(self.red_led_slider, 0, 1, 1, 5)
 
@@ -135,7 +135,7 @@ class PCCTesterWidget(BaseTabWidget):
         green_led_label = QtWidgets.QLabel("Green")
         led_layout.addWidget(green_led_label, 1, 0, 1, 1)
 
-        self.green_led_slider = QtWidgets.QSlider(QtCore.Qt.Horizontal)
+        self.green_led_slider = QtWidgets.QSlider(QtCore.Qt.Orientation.Horizontal)
         self.green_led_slider.setRange(0, 255)
         led_layout.addWidget(self.green_led_slider, 1, 1, 1, 5)
 
@@ -149,7 +149,7 @@ class PCCTesterWidget(BaseTabWidget):
         blue_led_label = QtWidgets.QLabel("Blue")
         led_layout.addWidget(blue_led_label, 2, 0, 1, 1)
 
-        self.blue_led_slider = QtWidgets.QSlider(QtCore.Qt.Horizontal)
+        self.blue_led_slider = QtWidgets.QSlider(QtCore.Qt.Orientation.Horizontal)
         self.blue_led_slider.setRange(0, 255)
         led_layout.addWidget(self.blue_led_slider, 2, 1, 1, 5)
 

--- a/GUI/app/tabs/thermal_view_control.py
+++ b/GUI/app/tabs/thermal_view_control.py
@@ -121,7 +121,7 @@ class ThermalView(QtWidgets.QWidget):
             method="cubic",
         )
 
-        pen = QtGui.QPen(QtCore.Qt.NoPen)
+        pen = QtGui.QPen(QtCore.Qt.PenStyle.NoPen)
         self.canvas.clear()
 
         for ix, row in enumerate(bicubic):
@@ -281,7 +281,7 @@ class JoystickWidget(BaseTabWidget):
 
         # painter.drawEllipse(bounds)
         painter.drawRect(bounds)
-        painter.setBrush(QtCore.Qt.black)
+        painter.setBrush(QtCore.Qt.GlobalColor.black)
 
         painter.drawEllipse(self._center_ellipse())
 
@@ -326,7 +326,7 @@ class ThermalViewControlWidget(BaseTabWidget):
         Build the GUI layout
         """
         layout = QtWidgets.QHBoxLayout(self)
-        layout_splitter = QtWidgets.QSplitter(QtCore.Qt.Horizontal)
+        layout_splitter = QtWidgets.QSplitter(QtCore.Qt.Orientation.Horizontal)
         self.setLayout(layout)
 
         # viewer
@@ -397,7 +397,7 @@ class ThermalViewControlWidget(BaseTabWidget):
 
         self.laser_toggle_label = QtWidgets.QLabel()
         self.laser_toggle_label.setAlignment(
-            QtCore.Qt.AlignRight | QtCore.Qt.AlignVCenter
+            QtCore.Qt.AlignmentFlag.AlignRight | QtCore.Qt.AlignmentFlag.AlignVCenter
         )
         laser_toggle_layout.addWidget(self.laser_toggle_label)
 

--- a/GUI/app/tabs/vmc_control.py
+++ b/GUI/app/tabs/vmc_control.py
@@ -92,7 +92,10 @@ class VMCControlWidget(BaseTabWidget):
             servo_layout.addWidget(servo_close_button)
 
             servo_label = QtWidgets.QLabel()
-            servo_label.setAlignment(QtCore.Qt.AlignRight | QtCore.Qt.AlignVCenter)
+            servo_label.setAlignment(
+                QtCore.Qt.AlignmentFlag.AlignRight
+                | QtCore.Qt.AlignmentFlag.AlignVCenter
+            )
             servo_layout.addWidget(servo_label)
             self.servo_labels.append(servo_label)
 

--- a/GUI/app/tabs/vmc_telemetry.py
+++ b/GUI/app/tabs/vmc_telemetry.py
@@ -38,7 +38,7 @@ class VMCTelemetryWidget(BaseTabWidget):
         # top groupbox
         top_groupbox = QtWidgets.QGroupBox("FCC Status")
         top_groupbox.setSizePolicy(
-            QtWidgets.QSizePolicy.Expanding, QtWidgets.QSizePolicy.Fixed
+            QtWidgets.QSizePolicy.Policy.Expanding, QtWidgets.QSizePolicy.Policy.Fixed
         )
         top_layout = QtWidgets.QFormLayout()
         top_groupbox.setLayout(top_layout)
@@ -73,7 +73,7 @@ class VMCTelemetryWidget(BaseTabWidget):
         # bottom groupbox
         bottom_group = QtWidgets.QFrame()
         bottom_group.setSizePolicy(
-            QtWidgets.QSizePolicy.Expanding, QtWidgets.QSizePolicy.Fixed
+            QtWidgets.QSizePolicy.Policy.Expanding, QtWidgets.QSizePolicy.Policy.Fixed
         )
         bottom_layout = QtWidgets.QHBoxLayout()
         bottom_group.setLayout(bottom_layout)
@@ -163,7 +163,7 @@ class VMCTelemetryWidget(BaseTabWidget):
         # Status
         module_status_groupbox = QtWidgets.QGroupBox("Module Status")
         module_status_groupbox.setSizePolicy(
-            QtWidgets.QSizePolicy.Expanding, QtWidgets.QSizePolicy.Fixed
+            QtWidgets.QSizePolicy.Policy.Expanding, QtWidgets.QSizePolicy.Policy.Fixed
         )
         module_status_layout = QtWidgets.QHBoxLayout()
         module_status_groupbox.setLayout(module_status_layout)

--- a/GUI/requirements.txt
+++ b/GUI/requirements.txt
@@ -1,8 +1,8 @@
 paho-mqtt==1.6.1
-PySide6-Essentials==6.3.1
+PySide6-Essentials==6.4.0.1
 loguru==0.6.0
-pyinstaller==5.1
+pyinstaller==5.6.2
 colour==0.1.5
 scipy==1.9.0
-numpy==1.23.2
+numpy==1.23.4
 bell-avr-libraries[mqtt,serial]==0.1.12

--- a/GUI/requirements.txt
+++ b/GUI/requirements.txt
@@ -5,4 +5,4 @@ pyinstaller==5.1
 colour==0.1.5
 scipy==1.9.0
 numpy==1.23.2
-bell-avr-libraries[mqtt,serial]==0.1.9
+bell-avr-libraries[mqtt,serial]==0.1.12

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,13 +5,13 @@
   "packages": {
     "": {
       "dependencies": {
-        "pyright": "^1.1.269"
+        "pyright": "^1.1.277"
       }
     },
     "node_modules/pyright": {
-      "version": "1.1.269",
-      "resolved": "https://registry.npmjs.org/pyright/-/pyright-1.1.269.tgz",
-      "integrity": "sha512-n3Q1ccQ4nzMmFGC8B6WUmuoylrkxrknlvpt1ODDbmXUFJlMQSNGLIoZYFZlnP0lt0b4tpO+nDaK1q0lI0nQaxA==",
+      "version": "1.1.278",
+      "resolved": "https://registry.npmjs.org/pyright/-/pyright-1.1.278.tgz",
+      "integrity": "sha512-at3j7c1fFzB6Jl4+bpr9QPRC/+1gH2gAR/M6GIRS312CHE2JMt8FZRflTbuxEB8IfQAtR+l3YoRMoS1vqF28jw==",
       "bin": {
         "pyright": "index.js",
         "pyright-langserver": "langserver.index.js"
@@ -23,9 +23,9 @@
   },
   "dependencies": {
     "pyright": {
-      "version": "1.1.269",
-      "resolved": "https://registry.npmjs.org/pyright/-/pyright-1.1.269.tgz",
-      "integrity": "sha512-n3Q1ccQ4nzMmFGC8B6WUmuoylrkxrknlvpt1ODDbmXUFJlMQSNGLIoZYFZlnP0lt0b4tpO+nDaK1q0lI0nQaxA=="
+      "version": "1.1.278",
+      "resolved": "https://registry.npmjs.org/pyright/-/pyright-1.1.278.tgz",
+      "integrity": "sha512-at3j7c1fFzB6Jl4+bpr9QPRC/+1gH2gAR/M6GIRS312CHE2JMt8FZRflTbuxEB8IfQAtR+l3YoRMoS1vqF28jw=="
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
   "dependencies": {
-    "pyright": "^1.1.269"
+    "pyright": "^1.1.277"
   }
 }

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
-black==22.8.0
+black==22.10.0
 isort==5.10.1
-autoflake==1.5.3
+autoflake==1.7.7
 pyleft==1.1.1
-pyproject-flake8==0.0.1a5
+pyproject-flake8==5.0.4.post1


### PR DESCRIPTION
Adds topic autocomplete to MQTT debugger. In conjunction with https://github.com/bellflight/AVR-Python-Libraries/pull/29,
adds the ability to pre-fill the payload structure as well.

![image](https://user-images.githubusercontent.com/8636459/199874773-029c940a-a800-465b-8881-386b8cd7d1c3.png)

![image](https://user-images.githubusercontent.com/8636459/199874793-4054de88-c4c4-4101-8ce2-afd825852297.png)

![image](https://user-images.githubusercontent.com/8636459/199874811-b7691bfc-bb10-40fd-bdad-9f7be36bab95.png)
